### PR TITLE
feat: Disable CreateProject endpoint in single-namespace mode

### DIFF
--- a/components/backend/internal/handlers/projects.go
+++ b/components/backend/internal/handlers/projects.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -96,6 +97,16 @@ func ListProjects(c *gin.Context) {
 
 // CreateProject creates a new Ambient-managed project
 func CreateProject(c *gin.Context) {
+	// Check if running in single-namespace mode
+	if os.Getenv("SINGLE_NAMESPACE_MODE") == "true" {
+		c.JSON(http.StatusNotImplemented, gin.H{
+			"error":   "Project creation disabled in single-namespace mode",
+			"message": "This deployment only supports the namespace: vteam--test1",
+			"contact": "Contact platform administrator to provision additional namespaces",
+		})
+		return
+	}
+
 	reqK8s, _ := middleware.GetK8sClientsForRequest(c)
 	var req types.CreateProjectRequest
 	if err := c.ShouldBindJSON(&req); err != nil {


### PR DESCRIPTION
## Summary

Implements issue #3: Disable the CreateProject endpoint in the backend API when running in single-namespace mode.

## Changes

- Added `os` import to support environment variable checking
- Added `SINGLE_NAMESPACE_MODE` environment variable check to `CreateProject()` function
- Returns HTTP 501 (Not Implemented) with helpful error message when in single-namespace mode
- Existing multi-namespace functionality remains unchanged

## Testing

- Backend returns HTTP 501 when `SINGLE_NAMESPACE_MODE=true`
- Error message is clear and actionable
- Existing functionality works when `SINGLE_NAMESPACE_MODE=false`

Closes #3

---

Generated with [Claude Code](https://claude.ai/code)