### PR TITLE
Convert ClusterRoles to namespace-scoped Roles

### DIFF
--- a/vteam-mpp-deployment/roles/ambient-project-admin.yaml
+++ b/vteam-mpp-deployment/roles/ambient-project-admin.yaml
@@ -1,0 +1,45 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ambient-project-admin
+  namespace: vteam--test1
+rules:
+# AgenticSessions and ProjectSettings (full CRUD)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions", "projectsettings", "rfeworkflows"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions/status", "projectsettings/status", "rfeworkflows/status"]
+  verbs: ["get", "update", "patch"]
+# Secrets and ConfigMaps (full management)
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# ServiceAccounts (full management for access keys)
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Token creation for ServiceAccounts
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]
+# RBAC resources (full permission management)
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Jobs (full management)
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "delete"]
+# Pods (monitoring)
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+# Namespaces (project management)
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# OpenShift Projects (project management)
+- apiGroups: ["project.openshift.io"]
+  resources: ["projects"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/vteam-mpp-deployment/roles/ambient-project-edit.yaml
+++ b/vteam-mpp-deployment/roles/ambient-project-edit.yaml
@@ -1,0 +1,52 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ambient-project-edit
+  namespace: vteam--test1
+rules:
+# AgenticSessions (full CRUD)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions/status"]
+  verbs: ["get", "update", "patch"]
+# RFEWorkflows (full CRUD)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["rfeworkflows"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["rfeworkflows/status"]
+  verbs: ["get", "update", "patch"]
+# ProjectSettings (read-only)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["projectsettings"]
+  verbs: ["get", "list", "watch"]
+# ConfigMaps (read Git config during session creation)
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]
+# Secrets (only for creating runner tokens during session provisioning)
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+# Jobs (session management - can delete jobs during stopSession)
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "delete"]
+# Pods (monitoring)
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+# ServiceAccounts (for provisioning runner tokens)
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "list", "create", "update", "patch"]
+# RBAC resources (for provisioning runner permissions)
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "list", "create", "update", "patch", "delete"]
+# Token creation for ServiceAccounts
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]

--- a/vteam-mpp-deployment/roles/ambient-project-view.yaml
+++ b/vteam-mpp-deployment/roles/ambient-project-view.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ambient-project-view
+  namespace: vteam--test1
+rules:
+# AgenticSessions and ProjectSettings (read-only)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions", "projectsettings", "rfeworkflows"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions/status", "projectsettings/status", "rfeworkflows/status"]
+  verbs: ["get"]
+# Jobs and Pods (monitoring)
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Description
Converts the 3 ambient-project ClusterRoles to namespace-scoped Roles for deployment to vteam--test1.

## Changes
- Created ambient-project-admin Role with full CRUD permissions
- Created ambient-project-edit Role with session management permissions
- Created ambient-project-view Role with read-only permissions
- All rules accurately copied from original ClusterRoles
- Namespace scoped to vteam--test1

Resolves #5

Generated with [Claude Code](https://claude.ai/code)