### PR TITLE
feat: Update operator to reference namespace Roles instead of ClusterRoles

### DIFF
--- a/components/operator/main.go
+++ b/components/operator/main.go
@@ -987,7 +987,7 @@ func ensureRoleBinding(namespace, groupName, role string) error {
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
+			Kind:     "Role",
 			Name:     roleName,
 		},
 		Subjects: []rbacv1.Subject{


### PR DESCRIPTION
Resolves #6

This PR implements Phase 2 of the RBAC conversion by updating the operator to reference namespace-scoped Roles instead of ClusterRoles.

## Changes
- Updated `ensureRoleBinding()` function in `components/operator/main.go`
- Changed `RoleRef.Kind` from 'ClusterRole' to 'Role' at line 990

This change is part of Epic #1 and depends on #5.

Generated with [Claude Code](https://claude.ai/code)