### PR TITLE
feat: Add consolidated namespace-scoped RBAC manifest (03-rbac.yaml)

### DIFF
--- a/components/manifests/03-rbac.yaml
+++ b/components/manifests/03-rbac.yaml
@@ -1,0 +1,255 @@
+# Phase 3: Complete RBAC Configuration
+# This file contains all namespace-scoped Roles and RoleBindings for vTeam components
+# Namespace is injected by kustomize
+
+---
+# Backend API Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backend-api
+
+---
+# Backend API Role (namespace-scoped permissions)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backend-api
+rules:
+# ServiceAccounts (only for updating last-used annotations on access keys)
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "patch"]
+
+# RFEWorkflow custom resources (full CRUD + status updates)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["rfeworkflows"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["rfeworkflows/status"]
+  verbs: ["get", "update", "patch"]
+
+---
+# Backend API RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backend-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backend-api
+subjects:
+- kind: ServiceAccount
+  name: backend-api
+
+---
+# Operator Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agentic-operator
+
+---
+# Operator Role (namespace-scoped permissions)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agentic-operator
+rules:
+# AgenticSession custom resources (read-only + status updates)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions/status"]
+  verbs: ["update"]
+
+# ProjectSettings custom resources (create + read + status updates)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["projectsettings"]
+  verbs: ["get", "list", "watch", "create"]
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["projectsettings/status"]
+  verbs: ["update"]
+
+# Jobs (create and monitor for session execution)
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "create"]
+
+# Pods (for getting logs from failed jobs)
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+
+# PersistentVolumeClaims (create workspace PVCs)
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "create"]
+
+# Services (create per-namespace content services)
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "create"]
+
+# Deployments (create per-namespace content services)
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["create"]
+
+# RoleBindings (create group access bindings)
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["rolebindings"]
+  verbs: ["get", "create"]
+
+---
+# Operator RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agentic-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agentic-operator
+subjects:
+- kind: ServiceAccount
+  name: agentic-operator
+
+---
+# Ambient Project Admin Role
+# Provides full administrative access to project resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ambient-project-admin
+rules:
+# AgenticSessions and ProjectSettings (full CRUD)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions", "projectsettings", "rfeworkflows"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions/status", "projectsettings/status", "rfeworkflows/status"]
+  verbs: ["get", "update", "patch"]
+
+# Secrets and ConfigMaps (full management)
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# ServiceAccounts (full management for access keys)
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# Token creation for ServiceAccounts
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]
+
+# RBAC resources (full permission management)
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+# Jobs (full management)
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "delete"]
+
+# Pods (monitoring)
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+
+---
+# Ambient Project Edit Role
+# Provides edit access to project resources (can create sessions, manage workflows)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ambient-project-edit
+rules:
+# AgenticSessions (full CRUD)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions/status"]
+  verbs: ["get", "update", "patch"]
+
+# RFEWorkflows (full CRUD)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["rfeworkflows"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["rfeworkflows/status"]
+  verbs: ["get", "update", "patch"]
+
+# ProjectSettings (read-only)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["projectsettings"]
+  verbs: ["get", "list", "watch"]
+
+# ConfigMaps (read Git config during session creation)
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]
+
+# Secrets (only for creating runner tokens during session provisioning)
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+
+# Jobs (session management - can delete jobs during stopSession)
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "delete"]
+
+# Pods (monitoring)
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+
+# ServiceAccounts (for provisioning runner tokens)
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "list", "create", "update", "patch"]
+
+# RBAC resources (for provisioning runner permissions)
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "list", "create", "update", "patch", "delete"]
+
+# Token creation for ServiceAccounts
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]
+
+---
+# Ambient Project View Role
+# Provides read-only access to project resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ambient-project-view
+rules:
+# AgenticSessions and ProjectSettings (read-only)
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions", "projectsettings", "rfeworkflows"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["vteam.ambient-code"]
+  resources: ["agenticsessions/status", "projectsettings/status", "rfeworkflows/status"]
+  verbs: ["get"]
+
+# Jobs and Pods (monitoring)
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]

--- a/components/manifests/rbac/kustomization.yaml
+++ b/components/manifests/rbac/kustomization.yaml
@@ -1,16 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- operator-sa.yaml
-- operator-clusterrole.yaml
-- operator-clusterrolebinding.yaml
-- backend-sa.yaml
-- backend-clusterrole.yaml
-- backend-clusterrolebinding.yaml
-- ambient-project-admin-clusterrole.yaml
-- ambient-project-edit-clusterrole.yaml
-- ambient-project-view-clusterrole.yaml
+# Phase 3: Consolidated namespace-scoped RBAC
+- ../03-rbac.yaml
+# Frontend requires ClusterRole for authentication
 - frontend-rbac.yaml
+# Aggregate ClusterRoles for OpenShift/K8s admin role
 - aggregate-agenticsessions-admin.yaml
 - aggregate-projectsettings-admin.yaml
 - aggregate-rfeworkflows-admin.yaml


### PR DESCRIPTION
## Summary
- Create 03-rbac.yaml with backend/operator Roles and RoleBindings
- Add 3 ambient project Roles: admin, edit, view (namespace-scoped)
- Replace ClusterRole-based RBAC with namespace-scoped Roles
- Addresses showstopper #7 (backend missing permissions)

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)