### PR TITLE
feat: add numbered namespace and CRD manifests for Phase 3

### DIFF
--- a/components/manifests/01-namespace.yaml
+++ b/components/manifests/01-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ambient-code
+  labels:
+    name: ambient-code
+    app: vteam
+    openshift.io/cluster-monitoring: "true"
+    cost-center: "687"
+  annotations:
+    openshift.io/description: "vTeam Ambient Agentic Runner - AI-powered automation system"
+    openshift.io/display-name: "vTeam Ambient Runner"
+    app.kubernetes.io/name: ambient-code
+    app.kubernetes.io/part-of: ambient-code

--- a/components/manifests/02-crds.yaml
+++ b/components/manifests/02-crds.yaml
@@ -1,0 +1,302 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: agenticsessions.vteam.ambient-code
+spec:
+  group: vteam.ambient-code
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            required:
+            - prompt
+            properties:
+              interactive:
+                type: boolean
+                description: "When true, run session in interactive chat mode using inbox/outbox files"
+              prompt:
+                type: string
+                description: "The initial prompt for the agentic session"
+              displayName:
+                type: string
+                description: "A descriptive display name for the agentic session generated from prompt and website"
+              llmSettings:
+                type: object
+                properties:
+                  model:
+                    type: string
+                    default: "claude-3-7-sonnet-latest"
+                  temperature:
+                    type: number
+                    default: 0.7
+                  maxTokens:
+                    type: integer
+                    default: 4000
+                description: "LLM configuration settings"
+              timeout:
+                type: integer
+                default: 300
+                description: "Timeout in seconds for the agentic session"
+              gitConfig:
+                type: object
+                description: "Git configuration for repository operations"
+                properties:
+                  user:
+                    type: object
+                    description: "Git user configuration"
+                    properties:
+                      name:
+                        type: string
+                        description: "Git user name for commits"
+                      email:
+                        type: string
+                        description: "Git user email for commits"
+                  authentication:
+                    type: object
+                    description: "Git authentication configuration"
+                    properties:
+                      sshKeySecret:
+                        type: string
+                        description: "Name of Kubernetes secret containing SSH private key"
+                      tokenSecret:
+                        type: string
+                        description: "Name of Kubernetes secret containing Git access token"
+                  repositories:
+                    type: array
+                    description: "List of Git repositories to clone"
+                    items:
+                      type: object
+                      properties:
+                        url:
+                          type: string
+                          description: "Git repository URL"
+                        branch:
+                          type: string
+                          default: "main"
+                          description: "Branch to checkout"
+                        clonePath:
+                          type: string
+                          description: "Relative path where to clone the repository"
+              paths:
+                type: object
+                description: "PVC storage paths used by the runner"
+                properties:
+                  workspace:
+                    type: string
+                    description: "Root workspace directory on PVC containing repos, .claude, specs, etc."
+                  messages:
+                    type: string
+                    description: "Path on PVC where conversation messages are stored (e.g., /sessions/{id}/messages.json)"
+                  inbox:
+                    type: string
+                    description: "Path on PVC where user chat inputs are appended as JSONL (e.g., /sessions/{id}/inbox.jsonl)"
+          status:
+            type: object
+            properties:
+              phase:
+                type: string
+                enum:
+                - "Pending"
+                - "Creating"
+                - "Running"
+                - "Completed"
+                - "Failed"
+                - "Stopped"
+                - "Error"
+                default: "Pending"
+              message:
+                type: string
+                description: "Status message or error details"
+              startTime:
+                type: string
+                format: date-time
+              completionTime:
+                type: string
+                format: date-time
+              jobName:
+                type: string
+                description: "Name of the Kubernetes job created for this session"
+              stateDir:
+                type: string
+                description: "Directory path where session state files are stored"
+              # Result summary fields from the runner's ResultMessage
+              subtype:
+                type: string
+                description: "Result subtype (e.g., success, error, interrupted)"
+              is_error:
+                type: boolean
+                description: "Whether the run ended with an error"
+              num_turns:
+                type: integer
+                description: "Number of conversation turns in the run"
+              session_id:
+                type: string
+                description: "Runner session identifier"
+              total_cost_usd:
+                type: number
+                description: "Total cost of the run in USD as reported by the runner"
+              usage:
+                type: object
+                description: "Token and request usage breakdown"
+                x-kubernetes-preserve-unknown-fields: true
+              result:
+                type: string
+                description: "Final result text as reported by the runner"
+    additionalPrinterColumns:
+    - name: Phase
+      type: string
+      description: Current phase of the agentic session
+      jsonPath: .status.phase
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: agenticsessions
+    singular: agenticsession
+    kind: AgenticSession
+    shortNames:
+    - as
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rfeworkflows.vteam.ambient-code
+spec:
+  group: vteam.ambient-code
+  names:
+    kind: RFEWorkflow
+    listKind: RFEWorkflowList
+    plural: rfeworkflows
+    singular: rfeworkflow
+    shortNames:
+    - rfe
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            required: [title, description]
+            properties:
+              title:
+                type: string
+              description:
+                type: string
+              repositories:
+                  type: array
+                  description: "List of Git repositories to clone"
+                  items:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                        description: "Git repository URL"
+                      branch:
+                        type: string
+                        default: "main"
+                        description: "Branch to checkout"
+                      clonePath:
+                        type: string
+                        description: "Relative path where to clone the repository"
+              workspacePath:
+                type: string
+              jiraLinks:
+                type: array
+                description: "Links between workspace files and Jira issues"
+                items:
+                  type: object
+                  required: [path, jiraKey]
+                  properties:
+                    path:
+                      type: string
+                      description: "Workspace-relative path to the document"
+                    jiraKey:
+                      type: string
+                      description: "Jira issue key (e.g., PROJ-123)"
+          status:
+            type: object
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: projectsettings.vteam.ambient-code
+spec:
+  group: vteam.ambient-code
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-validations:
+        - rule: "self.metadata.name == 'projectsettings'"
+          message: "metadata.name must be 'projectsettings' (singleton per namespace)"
+        properties:
+          spec:
+            type: object
+            required:
+            - groupAccess
+            properties:
+              groupAccess:
+                type: array
+                description: "Group access configuration creating RoleBindings"
+                items:
+                  type: object
+                  required:
+                  - groupName
+                  - role
+                  properties:
+                    groupName:
+                      type: string
+                      description: "Name of the group to grant access"
+                    role:
+                      type: string
+                      enum:
+                      - "admin"
+                      - "edit"
+                      - "view"
+                      description: "Role to assign to the group (admin/edit/view)"
+              runnerSecretsName:
+                type: string
+                description: "Name of the Kubernetes Secret in this namespace that stores runner configuration key/value pairs"
+          status:
+            type: object
+            properties:
+              groupBindingsCreated:
+                type: integer
+                minimum: 0
+                description: "Number of group RoleBindings successfully created"
+    additionalPrinterColumns:
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: projectsettings
+    singular: projectsetting
+    kind: ProjectSettings
+    shortNames:
+    - ps


### PR DESCRIPTION
- Create 01-namespace.yaml with MPP labels (cost-center=687)
- Create 02-crds.yaml with all 3 CRDs (AgenticSession, RFEWorkflow, ProjectSettings)
- Supports deployment ordering for Phase 3 implementation

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)