### PR TITLE
feat: Add Phase 3 deployment manifests (04-06) with MPP configurations

### DIFF
--- a/components/manifests/04-backend-deployment.yaml
+++ b/components/manifests/04-backend-deployment.yaml
@@ -1,0 +1,87 @@
+# Phase 3: Backend API Deployment with MPP Configuration
+# Multi-Project Platform (MPP) supports both single-namespace and multi-namespace modes
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-api
+  labels:
+    app: backend-api
+    app.kubernetes.io/name: backend-api
+    app.kubernetes.io/part-of: vteam
+    app.kubernetes.io/component: api
+spec:
+  replicas: 1  # Single pod for RWO PVC
+  selector:
+    matchLabels:
+      app: backend-api
+  template:
+    metadata:
+      labels:
+        app: backend-api
+    spec:
+      serviceAccountName: backend-api
+      containers:
+      - name: backend-api
+        image: quay.io/ambient_code/vteam_backend:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PORT
+          value: "8080"
+        - name: AGENTS_DIR
+          value: "/app/agents"
+        # MPP Configuration: Controls whether to operate in single-namespace mode
+        # When true, all resources are created in the operator's namespace
+        # When false, each project gets its own namespace
+        - name: SINGLE_NAMESPACE_MODE
+          value: "false"
+        # MPP Configuration: Storage class for PersistentVolumeClaims
+        # Used when creating workspace PVCs for agentic sessions
+        - name: STORAGE_CLASS
+          value: "gp3-csi"
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-service
+  labels:
+    app: backend-api
+    app.kubernetes.io/name: backend-api
+    app.kubernetes.io/part-of: vteam
+spec:
+  selector:
+    app: backend-api
+  ports:
+  - port: 8080
+    targetPort: http
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/components/manifests/05-frontend-deployment.yaml
+++ b/components/manifests/05-frontend-deployment.yaml
@@ -1,0 +1,136 @@
+# Phase 3: Frontend Deployment with MPP Configuration
+# Multi-Project Platform (MPP) supports both single-namespace and multi-namespace modes
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/part-of: vteam
+    app.kubernetes.io/component: ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      serviceAccountName: frontend
+      containers:
+      - name: frontend
+        imagePullPolicy: Always
+        image: quay.io/ambient_code/vteam_frontend:latest
+        ports:
+        - containerPort: 3000
+          name: http
+        env:
+        - name: BACKEND_URL
+          value: "http://backend-service:8080/api"
+        - name: NODE_ENV
+          value: "production"
+        # MPP Configuration: Controls UI behavior for single vs multi-namespace mode
+        # When true, UI only shows resources in the current namespace
+        # When false, UI can show resources across multiple project namespaces
+        - name: SINGLE_NAMESPACE_MODE
+          value: "false"
+        # MPP Configuration: Storage class displayed in UI for workspace creation
+        # Informs users which storage class will be used for their workspaces
+        - name: STORAGE_CLASS
+          value: "gp3-csi"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      - name: oauth-proxy
+        image: quay.io/openshift/origin-oauth-proxy:4.14
+        args:
+        - --http-address=:8443
+        - --https-address=
+        - --provider=openshift
+        - --upstream=http://localhost:3000
+        - --client-id=ambient-frontend
+        - --client-secret-file=/etc/oauth/config/client-secret
+        - --cookie-secret-file=/etc/oauth/config/cookie_secret
+        - --cookie-expire=23h0m0s
+        - --pass-access-token
+        - --scope=user:full
+        - '--openshift-delegate-urls={"/": {"resource": "projects", "verb": "list"}}'
+        - --skip-auth-regex=^/metrics
+        ports:
+        - containerPort: 8443
+          name: dashboard-ui
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: dashboard-ui
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: dashboard-ui
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        volumeMounts:
+        - mountPath: /etc/oauth/config
+          name: oauth-config
+        - mountPath: /etc/tls/private
+          name: proxy-tls
+      volumes:
+      - name: oauth-config
+        secret:
+          secretName: frontend-oauth-config
+      - name: proxy-tls
+        secret:
+          secretName: dashboard-proxy-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-service
+  labels:
+    app: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/part-of: vteam
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: dashboard-proxy-tls
+spec:
+  selector:
+    app: frontend
+  ports:
+  - port: 3000
+    targetPort: http
+    protocol: TCP
+    name: http
+  - port: 8443
+    targetPort: dashboard-ui
+    protocol: TCP
+    name: dashboard-ui
+  type: ClusterIP

--- a/components/manifests/06-operator-deployment.yaml
+++ b/components/manifests/06-operator-deployment.yaml
@@ -1,0 +1,67 @@
+# Phase 3: Operator Deployment with MPP Configuration
+# Multi-Project Platform (MPP) supports both single-namespace and multi-namespace modes
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentic-operator
+  labels:
+    app: agentic-operator
+    app.kubernetes.io/name: agentic-operator
+    app.kubernetes.io/part-of: vteam
+    app.kubernetes.io/component: operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agentic-operator
+  template:
+    metadata:
+      labels:
+        app: agentic-operator
+    spec:
+      serviceAccountName: agentic-operator
+      containers:
+      - name: agentic-operator
+        image: quay.io/ambient_code/vteam_operator:latest
+        imagePullPolicy: Always
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: BACKEND_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: BACKEND_API_URL
+          value: "http://backend-service:8080/api"
+        - name: AMBIENT_CODE_RUNNER_IMAGE
+          value: "quay.io/ambient_code/vteam_claude_runner:latest"
+        - name: IMAGE_PULL_POLICY
+          value: "Always"
+        # MPP Configuration: Controls operator namespace creation behavior
+        # When true, operator creates all resources in its own namespace
+        # When false, operator creates a new namespace for each project
+        - name: SINGLE_NAMESPACE_MODE
+          value: "false"
+        # MPP Configuration: Storage class for operator-created PVCs
+        # Used when creating workspace PVCs for agentic sessions
+        # Operator passes this to the backend when provisioning resources
+        - name: STORAGE_CLASS
+          value: "gp3-csi"
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - "ps aux | grep '[o]perator' || exit 1"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+      restartPolicy: Always

--- a/components/manifests/kustomization.yaml
+++ b/components/manifests/kustomization.yaml
@@ -10,14 +10,14 @@ namespace: ambient-code
 
 # Resources to include in deployment
 resources:
-- namespace.yaml
-- crds
-- rbac
+- 01-namespace.yaml
+- 02-crds.yaml
+- 03-rbac.yaml
+- 04-backend-deployment.yaml
+- 05-frontend-deployment.yaml
+- 06-operator-deployment.yaml
 - route.yaml
 - git-configmap.yaml
-- backend-deployment.yaml
-- frontend-deployment.yaml
-- operator-deployment.yaml
 images:
 - name: quay.io/ambient_code/vteam_backend:latest
   newName: quay.io/ambient_code/vteam_backend


### PR DESCRIPTION
## Summary

Create numbered deployment manifests for backend, frontend, and operator with Multi-Project Platform (MPP) configuration support.

## Changes

- Add `04-backend-deployment.yaml` with SINGLE_NAMESPACE_MODE and STORAGE_CLASS env vars
- Add `05-frontend-deployment.yaml` with SINGLE_NAMESPACE_MODE and STORAGE_CLASS env vars
- Add `06-operator-deployment.yaml` with SINGLE_NAMESPACE_MODE and STORAGE_CLASS env vars
- Update kustomization.yaml to reference new numbered files (01-06)
- Set default SINGLE_NAMESPACE_MODE=false (multi-namespace mode)
- Set default STORAGE_CLASS=gp3-csi

The MPP configuration allows the platform to operate in either:
- Single-namespace mode: All resources in operator's namespace
- Multi-namespace mode: Each project gets its own namespace

Resolves #9

🤖 Generated with [Claude Code](https://claude.ai/code)