### PR TITLE
feat(runner): add Claude Code plugin loading via PLUGINS_JSON

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/bridge.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/bridge.py
@@ -55,6 +55,7 @@ class ClaudeBridge(PlatformBridge):
         self._mcp_servers: dict = {}
         self._allowed_tools: list[str] = []
         self._system_prompt: dict = {}
+        self._plugins: list[dict[str, str]] = []
         self._stderr_lines: list[str] = []
         # Preserved session IDs across adapter rebuilds (e.g. repo additions)
         self._saved_session_ids: dict[str, str] = {}
@@ -364,6 +365,28 @@ class ClaudeBridge(PlatformBridge):
 
         system_prompt = build_sdk_system_prompt(self._context.workspace_path, cwd_path)
 
+        # Discover plugins cloned by init container
+        plugins_json = os.getenv("PLUGINS_JSON", "").strip()
+        plugins: list[dict[str, str]] = []
+        if plugins_json:
+            import json as _json
+
+            try:
+                for entry in _json.loads(plugins_json):
+                    name = entry.get("url", "").rstrip("/").split("/")[-1]
+                    if name.endswith(".git"):
+                        name = name[:-4]
+                    plugin_path = os.path.join(
+                        self._context.workspace_path, "plugins", name
+                    )
+                    if os.path.isdir(plugin_path):
+                        plugins.append({"type": "local", "path": plugin_path})
+                        logger.info(f"Plugin discovered: {name} at {plugin_path}")
+                    else:
+                        logger.warning(f"Plugin dir not found: {plugin_path}")
+            except Exception as exc:
+                logger.warning(f"Failed to parse PLUGINS_JSON: {exc}")
+
         # Store results
         self._configured_model = configured_model
         self._cwd_path = cwd_path
@@ -371,6 +394,7 @@ class ClaudeBridge(PlatformBridge):
         self._mcp_servers = mcp_servers
         self._allowed_tools = allowed_tools
         self._system_prompt = system_prompt
+        self._plugins = plugins
 
     # ------------------------------------------------------------------
     # Private: adapter lifecycle
@@ -405,6 +429,8 @@ class ClaudeBridge(PlatformBridge):
             options["add_dirs"] = self._add_dirs
         if self._configured_model:
             options["model"] = self._configured_model
+        if self._plugins:
+            options["plugins"] = self._plugins
 
         adapter = ClaudeAgentAdapter(
             name="claude_code_runner",

--- a/components/runners/state-sync/hydrate.sh
+++ b/components/runners/state-sync/hydrate.sh
@@ -234,6 +234,46 @@ else
     echo "No repositories configured in spec"
 fi
 
+# Clone plugins from PLUGINS_JSON
+if [ -n "$PLUGINS_JSON" ] && [ "$PLUGINS_JSON" != "null" ] && [ "$PLUGINS_JSON" != "" ]; then
+    echo "Cloning plugins from spec..."
+    PLUGIN_COUNT=$(echo "$PLUGINS_JSON" | jq -e 'if type == "array" then length else 0 end' 2>/dev/null || echo "0")
+    echo "Found $PLUGIN_COUNT plugins to clone"
+    if [ "$PLUGIN_COUNT" -gt 0 ]; then
+        mkdir -p /workspace/plugins
+        i=0
+        while [ $i -lt $PLUGIN_COUNT ]; do
+            PLUGIN_URL=$(echo "$PLUGINS_JSON" | jq -r ".[$i].url // empty" 2>/dev/null || echo "")
+            PLUGIN_BRANCH=$(echo "$PLUGINS_JSON" | jq -r ".[$i].branch // empty" 2>/dev/null || echo "")
+            PLUGIN_NAME=$(basename "$PLUGIN_URL" .git 2>/dev/null || echo "")
+
+            if [ -n "$PLUGIN_NAME" ] && [ -n "$PLUGIN_URL" ] && [ "$PLUGIN_URL" != "null" ]; then
+                PLUGIN_DIR="/workspace/plugins/$PLUGIN_NAME"
+                git config --global --add safe.directory "$PLUGIN_DIR" 2>/dev/null || true
+
+                if [ -n "$PLUGIN_BRANCH" ]; then
+                    echo "  Cloning plugin $PLUGIN_NAME (branch: $PLUGIN_BRANCH)..."
+                    if git clone --branch "$PLUGIN_BRANCH" --single-branch --depth 1 "$PLUGIN_URL" "$PLUGIN_DIR" 2>&1; then
+                        echo "  ✓ Cloned plugin $PLUGIN_NAME"
+                    else
+                        echo "  ⚠ Failed to clone plugin $PLUGIN_NAME"
+                    fi
+                else
+                    echo "  Cloning plugin $PLUGIN_NAME (default branch)..."
+                    if git clone --single-branch --depth 1 "$PLUGIN_URL" "$PLUGIN_DIR" 2>&1; then
+                        echo "  ✓ Cloned plugin $PLUGIN_NAME"
+                    else
+                        echo "  ⚠ Failed to clone plugin $PLUGIN_NAME"
+                    fi
+                fi
+            fi
+            i=$((i + 1))
+        done
+    fi
+else
+    echo "No plugins configured in spec"
+fi
+
 # Clone workflow repository
 if [ -n "$ACTIVE_WORKFLOW_GIT_URL" ] && [ "$ACTIVE_WORKFLOW_GIT_URL" != "null" ]; then
     WORKFLOW_BRANCH="${ACTIVE_WORKFLOW_BRANCH:-main}"


### PR DESCRIPTION
## Summary

Adds support for loading [Claude Code plugins](https://code.claude.com/docs/en/plugins) into ACP sessions via the existing `spec.environmentVariables` field. No CRD or operator changes required.

- **`hydrate.sh`**: Parses `PLUGINS_JSON` env var, shallow-clones each plugin repo to `/workspace/plugins/<name>/`
- **`bridge.py`**: Reads `PLUGINS_JSON`, resolves cloned paths, passes `SdkPluginConfig` entries to the Claude Agent SDK

## Reproducer

### Prerequisites

A plugin repo that follows the [Anthropic plugin spec](https://code.claude.com/docs/en/plugins) (`.claude-plugin/plugin.json` + `commands/`, `agents/`, `skills/` at root). For testing, use [`jeremyeder/ai-helpers-fixed`](https://github.com/jeremyeder/ai-helpers-fixed) — a patched fork of `opendatahub-io/ai-helpers` with the required manifest and symlinks.

### 1. Create a dev cluster from this PR

```bash
gh pr checkout 1106  # or whatever PR number this gets
make kind-up LOCAL_IMAGES=true CONTAINER_ENGINE=docker
```

> **Note:** If images hit `ImagePullBackOff` due to the `localhost/` prefix issue (PR #1105), tag and reload:
> ```bash
> for img in vteam_backend vteam_frontend vteam_operator vteam_claude_runner vteam_state_sync vteam_public_api vteam_api_server; do
>   docker tag "$img:latest" "localhost/$img:latest"
>   kind load docker-image "localhost/$img:latest" --name $(make kind-status 2>&1 | grep Cluster | awk '{print $2}')
> done
> kubectl rollout restart deployment -n ambient-code
> ```

### 2. Create the runner secrets

```bash
kubectl create secret generic ambient-runner-secrets -n ambient-code \
  --from-literal=ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY"
```

### 3. Create the MinIO bucket (if not already created)

```bash
kubectl exec deployment/minio -n ambient-code -- mc alias set local http://localhost:9000 minioadmin minioadmin123
kubectl exec deployment/minio -n ambient-code -- mc mb local/ambient-sessions
```

### 4. Apply the test CR

```yaml
apiVersion: vteam.ambient-code/v1alpha1
kind: AgenticSession
metadata:
  name: test-plugin
  namespace: ambient-code
spec:
  initialPrompt: "Run /odh-ai-helpers:rpm-examine https://download.copr.fedorainfracloud.org/results/@ocp-on-ppc64le/4_18_ocp_rebuild/fedora-41-ppc64le/08906879-cri-o/builder-live.log.gz https://download.copr.fedorainfracloud.org/results/@ocp-on-ppc64le/4_18_ocp_rebuild/fedora-41-ppc64le/08906879-cri-o/cri-o-1.31.5-3.rhaos4.18.gitf0d4a53.fc41.src.rpm"
  timeout: 600
  llmSettings:
    model: "claude-sonnet-4-20250514"
  environmentVariables:
    PLUGINS_JSON: '[{"url":"https://github.com/jeremyeder/ai-helpers-fixed","branch":"main"}]'
```

```bash
kubectl apply -f test-plugin-cr.yaml
```

### 5. Verify

Check init container cloned the plugin:

```bash
kubectl logs test-plugin-runner -c init-hydrate -n ambient-code | grep plugin
# Expected: ✓ Cloned plugin ai-helpers-fixed
```

Check runner discovered the plugin:

```bash
kubectl logs test-plugin-runner -c ambient-code-runner -n ambient-code | grep -i plugin
# Expected: Plugin discovered: ai-helpers-fixed at /workspace/plugins/ai-helpers-fixed
```

Open the UI (`make kind-port-forward`, then `http://localhost:<frontend-port>`) and confirm the session shows `odh-ai-helpers:*` skills in the response, with RPM build analysis output from the `/odh-ai-helpers:rpm-examine` command.

## How it works

```
CR spec.environmentVariables.PLUGINS_JSON
  → operator passes to init container + runner container (existing mechanism)
  → hydrate.sh clones to /workspace/plugins/<name>/
  → bridge.py reads PLUGINS_JSON, builds SdkPluginConfig list
  → ClaudeSDKClient(options={..., plugins=[{"type": "local", "path": "..."}]})
  → SDK loads .claude-plugin/plugin.json, discovers commands/agents/skills
```

## Test plan

- [x] Runner unit tests pass (474 passed, 0 failures)
- [x] Plugin clone succeeds in init container
- [x] Runner discovers plugin and passes to SDK
- [x] SDK loads plugin, skills/commands available in session
- [ ] Verify with private plugin repo + GitHub credentials
- [ ] Test multiple plugins in single session

🤖 Generated with [Claude Code](https://claude.com/claude-code)